### PR TITLE
Add Outlook unsubscribe planner prototype, docs, and sample data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: help demo demo-approve
+
+help:
+	@echo "Targets:"
+	@echo "  make demo         # run planner in preview mode"
+	@echo "  make demo-approve # run planner with --approve-all"
+
+demo:
+	python3 prototype/unsubscribe_planner.py \
+	  --input prototype/sample_messages.json \
+	  --allowlist prototype/allowlist.txt \
+	  --denylist prototype/denylist.txt
+
+demo-approve:
+	python3 prototype/unsubscribe_planner.py \
+	  --input prototype/sample_messages.json \
+	  --allowlist prototype/allowlist.txt \
+	  --denylist prototype/denylist.txt \
+	  --approve-all

--- a/README.md
+++ b/README.md
@@ -7,16 +7,32 @@ This project is building an Outlook automation that:
 3. Shows you a batch list first.
 4. Executes unsubscribes only after your explicit command: `OK unsubscribe from all`.
 
-## What I am making now
+## Easiest way to run it
 
-A practical **phase-1 prototype** you can run locally today:
+From the repo root:
 
-- `prototype/unsubscribe_planner.py`
-- Inputs: `sample_messages.json`, `allowlist.txt`, `denylist.txt`
-- Output: trusted/review/candidate report
-- Approval model: batch stays pending unless you pass `--approve-all`
+```bash
+make demo
+```
 
-## Quick start
+This prints:
+- trusted senders
+- review senders
+- candidate unsubscribe batch
+
+To simulate approval (`OK unsubscribe from all` equivalent):
+
+```bash
+make demo-approve
+```
+
+That writes a dry-run execution file to:
+
+- `prototype/executed_batch.json`
+
+## If you don't have make
+
+Preview mode:
 
 ```bash
 python3 prototype/unsubscribe_planner.py \
@@ -25,7 +41,7 @@ python3 prototype/unsubscribe_planner.py \
   --denylist prototype/denylist.txt
 ```
 
-Approve and execute the current batch:
+Approve + execute:
 
 ```bash
 python3 prototype/unsubscribe_planner.py \
@@ -34,6 +50,15 @@ python3 prototype/unsubscribe_planner.py \
   --denylist prototype/denylist.txt \
   --approve-all
 ```
+
+## What I am making now
+
+A practical **phase-1 prototype** you can run locally today:
+
+- `prototype/unsubscribe_planner.py`
+- Inputs: `sample_messages.json`, `allowlist.txt`, `denylist.txt`
+- Output: trusted/review/candidate report
+- Approval model: batch stays pending unless you pass `--approve-all`
 
 ## Next implementation plan
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
 # hello-world
-testing Github
-I like Java and I am trying to start a project on it
+
+This project is building an Outlook automation that:
+
+1. Scans recent email senders.
+2. Classifies each sender as trusted/review/unsubscribe-candidate.
+3. Shows you a batch list first.
+4. Executes unsubscribes only after your explicit command: `OK unsubscribe from all`.
+
+## What I am making now
+
+A practical **phase-1 prototype** you can run locally today:
+
+- `prototype/unsubscribe_planner.py`
+- Inputs: `sample_messages.json`, `allowlist.txt`, `denylist.txt`
+- Output: trusted/review/candidate report
+- Approval model: batch stays pending unless you pass `--approve-all`
+
+## Quick start
+
+```bash
+python3 prototype/unsubscribe_planner.py \
+  --input prototype/sample_messages.json \
+  --allowlist prototype/allowlist.txt \
+  --denylist prototype/denylist.txt
+```
+
+Approve and execute the current batch:
+
+```bash
+python3 prototype/unsubscribe_planner.py \
+  --input prototype/sample_messages.json \
+  --allowlist prototype/allowlist.txt \
+  --denylist prototype/denylist.txt \
+  --approve-all
+```
+
+## Next implementation plan
+
+1. Replace local JSON input with Microsoft Graph (`/me/messages`) via OAuth.
+2. Persist sender history + batches in SQLite/Postgres.
+3. Add approval commands (`show candidates`, `OK unsubscribe from all`, `unsubscribe batch <id>`).
+4. Add safe execution for `List-Unsubscribe` and fallback block/junk rules.
+5. Schedule regular runs (cron/Quartz).
+
+See `docs/outlook-trusted-unsubscribe-automation.md` for the full architecture.

--- a/docs/outlook-trusted-unsubscribe-automation.md
+++ b/docs/outlook-trusted-unsubscribe-automation.md
@@ -1,0 +1,136 @@
+# Outlook Trusted Sender Review + Unsubscribe Automation
+
+This document lays out a **safe, two-step automation** for Outlook:
+
+1. Fetch recent email senders.
+2. Classify them as trusted vs not trusted.
+3. Present a review list.
+4. Wait for explicit approval (`"OK, unsubscribe from all"`).
+5. Execute unsubscribes.
+6. Run on a schedule.
+
+## Important constraints
+
+- Any inbox access requires user authentication and consent (Microsoft Graph OAuth).
+- Unsubscribe actions are provider- and sender-dependent:
+  - Preferred: `List-Unsubscribe` headers (`mailto` or one-click URL).
+  - Fallback: move to junk/delete + block sender when unsubscribe is unavailable.
+- You should never auto-unsubscribe without explicit approval for each batch.
+
+## Recommended architecture
+
+- **Language/Runtime:** Java 21.
+- **Scheduler:** cron (or Quartz in-app scheduler).
+- **Email API:** Microsoft Graph API (`Mail.Read`, `Mail.ReadWrite`, `MailboxSettings.Read`, minimal scopes).
+- **Storage:** SQLite/Postgres for sender history and user decisions.
+- **Policy engine:** weighted trust score + allow/deny lists.
+- **Approval channel:** chat command, web UI button, or email reply token.
+
+## Data model
+
+### `sender_profile`
+- `sender_domain` (PK)
+- `sender_email`
+- `first_seen_at`
+- `last_seen_at`
+- `messages_30d`
+- `opened_30d`
+- `replied_30d`
+- `clicked_30d`
+- `contains_invoice_keywords` (bool)
+- `contains_security_keywords` (bool)
+- `list_unsubscribe_available` (bool)
+- `trust_score` (0-100)
+- `status` (`trusted`, `review`, `candidate_unsubscribe`, `blocked`)
+
+### `unsubscribe_batch`
+- `batch_id` (PK)
+- `created_at`
+- `status` (`pending_approval`, `approved`, `executed`, `expired`)
+
+### `unsubscribe_batch_item`
+- `batch_id`
+- `sender_domain`
+- `reason`
+- `action` (`unsubscribe_header`, `block_sender`, `move_to_junk`)
+- `executed_at`
+- `execution_result`
+
+## Trust scoring example
+
+Start from 50 and adjust:
+
+- +25 if sender in manual allowlist.
+- +20 if you replied in last 90 days.
+- +10 if messages include work/billing/security keywords.
+- -20 if never opened in 90 days.
+- -15 if high volume (>10/week) and low engagement.
+- -25 if marketing/newsletter and no clicks/replies ever.
+- -30 if user previously unsubscribed similar sender.
+
+Status mapping:
+
+- `>= 70`: trusted
+- `40..69`: review
+- `< 40`: candidate_unsubscribe
+
+## Batch flow
+
+1. Scheduled job runs daily.
+2. Pull recent messages and update sender profiles.
+3. Build candidate list (`candidate_unsubscribe`).
+4. Create `unsubscribe_batch` with itemized reasons.
+5. Send summary to user:
+   - sender
+   - trust score
+   - reason
+   - planned action
+6. Wait for approval command:
+   - `OK unsubscribe from all` (all in batch)
+   - `unsubscribe batch <id>`
+   - optional future: per-sender approvals
+7. Execute actions and log results.
+
+## Microsoft Graph implementation notes
+
+- Read messages: `/me/messages?$select=from,subject,receivedDateTime,internetMessageHeaders`
+- Parse `internetMessageHeaders` for `List-Unsubscribe` and `List-Unsubscribe-Post`.
+- For `mailto` unsubscribe: send templated message to target address.
+- For one-click URL unsubscribe:
+  - only allow HTTPS
+  - validate domain against sender domain or known vendor list
+  - use safe HTTP client with strict timeout and redirect limits
+- If no unsubscribe path, fallback to block/move-to-junk rule.
+
+## Safety guardrails
+
+- Require explicit approval for each batch (do not auto-execute).
+- Expire batch approvals after 24 hours.
+- Max unsubscribes per run (e.g., 50).
+- Keep immutable audit log of every action.
+- Dry-run mode for first week.
+
+## Suggested command contract
+
+### User-facing
+- `show unsubscribe candidates`
+- `show trusted senders`
+- `OK unsubscribe from all`
+- `unsubscribe batch <batch_id>`
+- `trust <sender@domain.com>`
+- `never unsubscribe <domain.com>`
+
+### Internal API
+- `POST /automation/run-scan`
+- `GET /automation/batches/{id}`
+- `POST /automation/batches/{id}/approve`
+- `POST /automation/batches/{id}/execute`
+
+## Minimal rollout plan
+
+1. Build read-only scanner + trust scoring report.
+2. Add approval workflow.
+3. Add unsubscribe execution for `List-Unsubscribe` only.
+4. Add block/junk fallback.
+5. Tune trust weights from your behavior data.
+

--- a/prototype/allowlist.txt
+++ b/prototype/allowlist.txt
@@ -1,0 +1,1 @@
+bank.com

--- a/prototype/denylist.txt
+++ b/prototype/denylist.txt
@@ -1,0 +1,1 @@
+social.com

--- a/prototype/executed_batch.json
+++ b/prototype/executed_batch.json
@@ -1,0 +1,19 @@
+{
+  "executed_at": "2026-04-18T10:47:56.124305+00:00",
+  "items": [
+    {
+      "sender": "newsletter@shop.com",
+      "domain": "shop.com",
+      "trust_score": 5,
+      "reason": "never opened, high volume with no engagement",
+      "action": "unsubscribe_header"
+    },
+    {
+      "sender": "updates@social.com",
+      "domain": "social.com",
+      "trust_score": 0,
+      "reason": "never opened, similar domain unsubscribed before",
+      "action": "unsubscribe_header"
+    }
+  ]
+}

--- a/prototype/sample_messages.json
+++ b/prototype/sample_messages.json
@@ -1,0 +1,8 @@
+[
+  {"sender": "alerts@bank.com", "subject": "Security verification code", "opened": true, "replied": false, "clicked": true, "list_unsubscribe": false},
+  {"sender": "newsletter@shop.com", "subject": "Big weekend sale", "opened": false, "replied": false, "clicked": false, "list_unsubscribe": true},
+  {"sender": "newsletter@shop.com", "subject": "Another sale", "opened": false, "replied": false, "clicked": false, "list_unsubscribe": true},
+  {"sender": "newsletter@shop.com", "subject": "Final reminder", "opened": false, "replied": false, "clicked": false, "list_unsubscribe": true},
+  {"sender": "billing@cloudvendor.com", "subject": "Invoice for April", "opened": true, "replied": false, "clicked": false, "list_unsubscribe": false},
+  {"sender": "updates@social.com", "subject": "New followers", "opened": false, "replied": false, "clicked": false, "list_unsubscribe": true}
+]

--- a/prototype/unsubscribe_planner.py
+++ b/prototype/unsubscribe_planner.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Dry-run planner for Outlook trusted-sender unsubscribe automation.
+
+This prototype does not connect to Microsoft Graph yet. It demonstrates the
+core policy and approval flow using local JSON input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+
+@dataclass
+class SenderStats:
+    sender: str
+    domain: str
+    messages_30d: int = 0
+    opened_30d: int = 0
+    replied_30d: int = 0
+    clicked_30d: int = 0
+    work_or_billing_keywords: bool = False
+    list_unsubscribe_available: bool = False
+    allowlisted: bool = False
+    previously_unsubscribed: bool = False
+
+
+@dataclass
+class BatchItem:
+    sender: str
+    domain: str
+    trust_score: int
+    reason: str
+    action: str
+
+
+def load_messages(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("Input JSON must be a list of message objects")
+    return data
+
+
+def keyword_hit(subject: str) -> bool:
+    subject_lower = subject.lower()
+    keywords = ("invoice", "receipt", "billing", "security", "mfa", "verification")
+    return any(k in subject_lower for k in keywords)
+
+
+def aggregate(messages: List[dict], allow_domains: set[str], deny_domains: set[str]) -> Dict[str, SenderStats]:
+    stats: Dict[str, SenderStats] = {}
+    for msg in messages:
+        sender = msg.get("sender", "").strip().lower()
+        if "@" not in sender:
+            continue
+        domain = sender.split("@", 1)[1]
+
+        s = stats.setdefault(sender, SenderStats(sender=sender, domain=domain))
+        s.messages_30d += 1
+        s.opened_30d += 1 if msg.get("opened") else 0
+        s.replied_30d += 1 if msg.get("replied") else 0
+        s.clicked_30d += 1 if msg.get("clicked") else 0
+        s.list_unsubscribe_available = s.list_unsubscribe_available or bool(msg.get("list_unsubscribe"))
+        s.work_or_billing_keywords = s.work_or_billing_keywords or keyword_hit(msg.get("subject", ""))
+        s.allowlisted = domain in allow_domains
+        s.previously_unsubscribed = domain in deny_domains
+    return stats
+
+
+def trust_score(s: SenderStats) -> int:
+    score = 50
+    if s.allowlisted:
+        score += 25
+    if s.replied_30d > 0:
+        score += 20
+    if s.work_or_billing_keywords:
+        score += 10
+    if s.opened_30d == 0:
+        score -= 20
+    if s.messages_30d > 10 and (s.opened_30d + s.clicked_30d + s.replied_30d) <= 2:
+        score -= 15
+    if s.clicked_30d == 0 and s.replied_30d == 0 and s.messages_30d >= 3:
+        score -= 25
+    if s.previously_unsubscribed:
+        score -= 30
+    return max(0, min(100, score))
+
+
+def classify(score: int) -> str:
+    if score >= 70:
+        return "trusted"
+    if score >= 40:
+        return "review"
+    return "candidate_unsubscribe"
+
+
+def reason_for(s: SenderStats, score: int) -> str:
+    reasons = []
+    if s.opened_30d == 0:
+        reasons.append("never opened")
+    if s.clicked_30d == 0 and s.replied_30d == 0 and s.messages_30d >= 3:
+        reasons.append("high volume with no engagement")
+    if s.previously_unsubscribed:
+        reasons.append("similar domain unsubscribed before")
+    if score >= 70:
+        reasons.append("active relationship")
+    return ", ".join(reasons) if reasons else "mixed signals"
+
+
+def action_for(s: SenderStats) -> str:
+    return "unsubscribe_header" if s.list_unsubscribe_available else "move_to_junk"
+
+
+def build_batch(stats: Dict[str, SenderStats]) -> List[BatchItem]:
+    items: List[BatchItem] = []
+    for sender, s in sorted(stats.items()):
+        score = trust_score(s)
+        status = classify(score)
+        if status == "candidate_unsubscribe":
+            items.append(
+                BatchItem(
+                    sender=sender,
+                    domain=s.domain,
+                    trust_score=score,
+                    reason=reason_for(s, score),
+                    action=action_for(s),
+                )
+            )
+    return items
+
+
+def print_report(stats: Dict[str, SenderStats], batch: List[BatchItem]) -> None:
+    trusted = []
+    review = []
+    candidate = []
+    for sender, s in sorted(stats.items()):
+        score = trust_score(s)
+        row = (sender, score)
+        status = classify(score)
+        if status == "trusted":
+            trusted.append(row)
+        elif status == "review":
+            review.append(row)
+        else:
+            candidate.append(row)
+
+    print("=== TRUSTED ===")
+    for sender, score in trusted:
+        print(f"- {sender} (score {score})")
+
+    print("\n=== REVIEW ===")
+    for sender, score in review:
+        print(f"- {sender} (score {score})")
+
+    print("\n=== CANDIDATE UNSUBSCRIBE BATCH ===")
+    for item in batch:
+        print(f"- {item.sender} (score {item.trust_score}) -> {item.action}; {item.reason}")
+
+
+def execute_batch(batch: List[BatchItem], state_path: Path) -> None:
+    state = {
+        "executed_at": datetime.now(timezone.utc).isoformat(),
+        "items": [asdict(item) for item in batch],
+    }
+    state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    print(f"Executed dry-run unsubscribe batch with {len(batch)} items.")
+    print(f"Wrote execution log to: {state_path}")
+
+
+def load_lines(path: Path | None) -> set[str]:
+    if path is None or not path.exists():
+        return set()
+    return {line.strip().lower() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Dry-run unsubscribe planner")
+    parser.add_argument("--input", required=True, type=Path, help="Path to sample messages JSON")
+    parser.add_argument("--allowlist", type=Path, help="Optional domain allowlist (one per line)")
+    parser.add_argument("--denylist", type=Path, help="Optional domain denylist (one per line)")
+    parser.add_argument("--approve-all", action="store_true", help="Execute candidate batch immediately")
+    parser.add_argument("--state", type=Path, default=Path("prototype/executed_batch.json"))
+    args = parser.parse_args()
+
+    allow_domains = load_lines(args.allowlist)
+    deny_domains = load_lines(args.denylist)
+    messages = load_messages(args.input)
+    stats = aggregate(messages, allow_domains=allow_domains, deny_domains=deny_domains)
+    batch = build_batch(stats)
+
+    print_report(stats, batch)
+
+    if args.approve_all:
+        execute_batch(batch, args.state)
+    else:
+        print("\nBatch is pending approval. Re-run with --approve-all to execute.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a safe phase-1 prototype to scan recent senders, score trust, and propose unsubscribes while requiring explicit approval.
- Document the intended architecture and policy for a production-grade Microsoft Graph based implementation.
- Include sample inputs and outputs so the planner can be run locally as a dry-run.

### Description

- Update `README.md` with project overview, quick start, and next implementation plan including the `OK unsubscribe from all` approval model.
- Add `docs/outlook-trusted-unsubscribe-automation.md` containing architecture, data model, trust scoring, flow, Graph notes, and safety guardrails.
- Add a prototype implementation `prototype/unsubscribe_planner.py` that aggregates `sample_messages.json`, computes `trust_score`, classifies senders, builds a candidate batch, and writes a dry-run execution log to `prototype/executed_batch.json` when run with `--approve-all`.
- Add sample data and lists: `prototype/sample_messages.json`, `prototype/allowlist.txt`, `prototype/denylist.txt`, and an example `prototype/executed_batch.json` output.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3606a7a488331836b2631bddfb758)